### PR TITLE
Adds some basic information on the bot home tab

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,6 +12,49 @@ logging.basicConfig(level=logging.INFO)
 # process_before_response must be True when running on FaaS
 app = App(process_before_response=True, signing_secret=os.getenv("SIGNING_SECRET"), token=os.getenv("BOT_TOKEN"))
 
+# Put some basic information on the bot home tab.
+@app.event("app_home_opened")
+def update_home_tab(client, event, logger):
+  try:
+    client.views_publish(
+      user_id = event["user"],
+      view={
+        "type": "home",
+        "callback_id": "home_view",
+        "blocks": [
+          {
+            "type": "section",
+            "text": {
+              "type": "mrkdwn",
+              "text": "*Welcome to PuzBot!* :tada:"
+            }
+          },
+          {
+            "type": "divider"
+          },
+          {
+            "type": "section",
+            "text": {
+              "type": "mrkdwn",
+              "text": "PuzBot is our attempt to streamline the mechanics of starting and stopping activity on a puzzle. More information about this is coming soon."
+            }
+          },
+          {
+            "type": "divider"
+          },
+          {
+            "type": "section",
+            "text": {
+              "type": "mrkdwn",
+              "text": "To contribute to Puzbot, please visit <https://github.com/adamshire123/puz-bot|*the Github repo*>"
+            }
+          }
+        ]
+      }
+    )
+
+  except Exception as e:
+    logger.error(f"Error publishing home tab: {e}")
 
 # for testing
 @app.command("/hello")


### PR DESCRIPTION
The point of this PR is to do two things:

1. Make sure that I'm remembering how best to contribute to someone else's repo (via a fork, etc)
2. Add a basic set of information to the bot's home tab. This is something the tutorials seem to all include, and I wonder whether using the home tab might help with a few things (linking to the project repo in case others want to contribute, as well as providing a way to create puzzles without risking typos on the command line)

We can always back out of the home tab, or just leave it very sparse with just a link to the bot repo, if you'd prefer that. Mostly I'm just wanting to make sure that I can contribute without making a hash of what you've already got working.