### PR TITLE
[WIP] Adds demonstration read-only modal

### DIFF
--- a/main.py
+++ b/main.py
@@ -79,6 +79,27 @@ def initialize_puzzle(body, say, ack):
     else:
         say("please provide a puzzle name: e.g. puz-salad-daze")
 
+# Listener for the demonstration modal
+@app.shortcut("demonstrate_modal")
+def demonstrate_modal(ack, shortcut, client, logger):
+  ack()
+  client.views_open(
+    trigger_id=shortcut["trigger_id"],
+    view={
+      "type": "modal",
+      "title": {"type": "plain_text", "text": "Demonstration modal box"},
+      "close": {"type": "plain_text", "text": "Close"},
+      "blocks": [
+        {
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": "This is a demonstration of a modal box invoked by a shortcut. If this were a working form, there would be input boxes and a submit button.\n\nThis is only a demonstration."
+          }
+        }
+      ]
+    }
+  )
 
 handler = SlackRequestHandler(app)
 


### PR DESCRIPTION
When done, this will add an option for the user to kick everything off via a modal dialog, rather than needing a command in the chat window.

As of now, it only adds a shortcut to display a modal box with a text message - there are no form elements, nor handlers for a form submission.

A stretch goal for this might be to use a button on the bot's home tab - but I'm going to try and leave that interaction alone for now.

This is in draft mode for now while I work out the modal form and submission handling. I'll chat with you soon about whether this type of interaction seems more promising than the command-line option.