### PR TITLE
Adds simple puzzle object, creates channels

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from google.cloud import pubsub_v1
 
 from slack_bolt import App
 from slack_bolt.adapter.google_cloud_functions import SlackRequestHandler
+from puzbot.puzzle import Puzzle
 
 logging.basicConfig(level=logging.INFO)
 
@@ -79,6 +80,15 @@ def initialize_puzzle(body, say, ack):
     else:
         say("please provide a puzzle name: e.g. puz-salad-daze")
 
+@app.command("/create-puzzle")
+def create_puzzle(ack, client, logger, say, command):
+  ack()
+  say(f"I have been requested to create a puzzle: \"{command['text']}\".")
+  # Create the Puzzle object, through which the Slack channel and Google sheet
+  # will be created.
+  draft = Puzzle()
+  draft.create(client, logger, say, command['text'])
+  say(f"I have finished attempting to create this puzzle.")
 
 handler = SlackRequestHandler(app)
 

--- a/puzbot/__init__.py
+++ b/puzbot/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import

--- a/puzbot/puzzle.py
+++ b/puzbot/puzzle.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+import os, logging
+
+class Puzzle():
+  """
+  This is a wrapper for a puzzle. The intent is to use this to handle both the
+  management of the Slack channel, as well as the Google Sheet, for a puzzle.
+  This includes creation and solution events.
+  """
+
+  def __init__(self):
+    self.data = {}
+    self.data["channel-name"] = ""
+    self.data["name"] = ""
+
+  def create(self, client, logger, say, puzzle_name):
+    self.data["name"] = puzzle_name
+    self.data["channel-name"] = self.set_channel_name(logger, puzzle_name)
+
+    try:
+      # Call the conversations.create method using the WebClient
+      # conversations_create requires the channels:manage bot scope
+      result = client.conversations_create(
+        name=self.data["channel-name"]
+      )
+      # Log the result which includes information like the ID of the conversation
+      logger.info(result)
+      say(f"The channel #{self.data["channel-name"]} has been created!")
+
+    except Exception as e:
+      # There is a more specific error which could be caught, but this works.
+      logger.error("Error creating channel: {}".format(e))
+      say(f"I tried to create the channel #{self.data["channel-name"]}. Unfortunately, I failed.")
+
+  def set_channel_name(self, logger, puzzle_name):
+    return "puzzle-" + puzzle_name.lower()


### PR DESCRIPTION
I think this is ready. At least, when I tried this approach in a separate bot project, it seems to work.

This adds a Puzzle model to the project, in an attempt to give us space to manage the abstractions of a puzzle without piling everything into `main.py`. It might be extended with separate abstractions for Slack channels and Google sheets, but I'm not sure that's needed at the moment. Theoretically, this would also give us an opportunity to test the model code on its own terms, but I haven't set up any tests yet.

For the moment, this anticipates a new command, `/create-puzzle`, but I'm open to using one of the commands you've already defined instead.

One caveat - eventually this will need more protection and handling of the provided name. These work:

```
/create-puzzle samplename
/create-puzzle SampleName
```

This does not:
```
/create-puzzle Sample Name
```

If you'd rather wait to merge this until we've got all the name handling in place, that's fine with me. I'll want to chat with you about what handling we need, obviously. So far I know we need to use lowercase, and we'll need to handle spaces in names. I'm not sure what other requirements exist.
